### PR TITLE
Change anchor "visibility" to "opacity"

### DIFF
--- a/sass/components/_asciidoc.scss
+++ b/sass/components/_asciidoc.scss
@@ -546,7 +546,7 @@ b.button:after {
     margin-left: -1.5ex;
     display: block;
     text-decoration: none !important;
-    visibility: hidden;
+    opacity: 0;
     text-align: center;
     font-weight: normal;
 
@@ -561,7 +561,7 @@ b.button:after {
 
   &:hover > a.anchor,
   > a.anchor:hover {
-    visibility: visible;
+    opacity: 1;
   }
 
   > a.link {


### PR DESCRIPTION
This is intended to fix an issue I've seen when anchor links cannot be "hovered" directly.  Without this PR, one must hover the title text itself, and then quickly move the mouse over to the anchor in order to access the clickable link.

With this change, the anchor link itself remains hoverable (and clickable) even when it is invisible, due to the use of "opacity" as opposed to "visibility."

Note that I've tested this manually in the browser's DevTools, but I haven't run this through the whole SASS build etc.  So additional testing here is welcome.  To test it, approach the (invisible) anchor link from above or from the left side, as opposed to first hovering the title text associated with it.  The anchor should reveal itself and work properly from any direction with this change.  It should also work better on mobile, where it will be touchable even without any hovering.

/cc @oddhack